### PR TITLE
Add /etc/nsswitch.conf

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM golang:1.9-alpine
 
-WORKDIR /go/src/github.com/abutaha/aws-es-proxy
+WORKDIR /go/src/github.com/msusta/aws-es-proxy
 COPY . .
 
 RUN apk add --update bash curl git && \
@@ -17,9 +17,11 @@ FROM alpine:3.7
 LABEL name="aws-es-proxy" \
       version="latest"
 
+RUN echo "hosts: files dns" > /etc/nsswitch.conf
+
 RUN apk --no-cache add ca-certificates
 WORKDIR /home/
-COPY --from=0 /go/src/github.com/abutaha/aws-es-proxy/aws-es-proxy /usr/local/bin/
+COPY --from=0 /go/src/github.com/msusta/aws-es-proxy/aws-es-proxy /usr/local/bin/
 
 ENV PORT_NUM 9200
 EXPOSE ${PORT_NUM}


### PR DESCRIPTION
This forces go DNS resolver to actually look into /etc/hosts and
allows container users to put in overrides. Eg. with docker by
using --add-host option.